### PR TITLE
Add Puppeteer invoice PDF pipeline with graceful jsPDF fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,6 @@ GEMINI_API_KEY="MY_GEMINI_API_KEY"
 # AI Studio automatically injects this at runtime with the Cloud Run service URL.
 # Used for self-referential links, OAuth callbacks, and API endpoints.
 APP_URL="MY_APP_URL"
+
+# Optional: local Puppeteer PDF microservice URL for high-quality invoice PDFs.
+VITE_PDF_SERVICE_URL="http://localhost:4173"

--- a/README.md
+++ b/README.md
@@ -18,3 +18,16 @@ View your app in AI Studio: https://ai.studio/apps/550b4257-5844-4142-b54e-8fc0a
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+## PDF generation with Puppeteer (improved quality)
+
+This app now supports a higher-quality PDF flow via Puppeteer.
+
+1. Install Puppeteer once:
+   `npm install puppeteer`
+2. Start PDF microservice:
+   `npm run pdf:server`
+3. (Optional) configure custom service URL in `.env.local`:
+   `VITE_PDF_SERVICE_URL=http://localhost:4173`
+
+If the Puppeteer service is not running, the app will fall back to the in-browser PDF generator automatically.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite --port=3000 --host=0.0.0.0",
     "build": "vite build",
     "preview": "vite preview",
+    "pdf:server": "node server/pdfServer.mjs",
     "clean": "rm -rf dist",
     "lint": "tsc --noEmit"
   },

--- a/server/pdfServer.mjs
+++ b/server/pdfServer.mjs
@@ -1,0 +1,56 @@
+import express from "express";
+
+const app = express();
+const port = Number(process.env.PDF_SERVER_PORT || 4173);
+
+app.use(express.json({ limit: "10mb" }));
+
+app.get("/health", (_req, res) => {
+  res.json({ ok: true, service: "puppeteer-pdf", date: new Date().toISOString() });
+});
+
+app.post("/api/render-invoice-pdf", async (req, res) => {
+  const html = typeof req.body?.html === "string" ? req.body.html : "";
+  const rawFileName = typeof req.body?.fileName === "string" ? req.body.fileName : "invoice.pdf";
+  const safeFileName = rawFileName.replace(/[^\w.-]/g, "_");
+
+  if (!html.trim()) {
+    res.status(400).json({ error: "html payload is required" });
+    return;
+  }
+
+  let browser;
+  try {
+    const puppeteerModule = await import("puppeteer");
+    const puppeteer = puppeteerModule.default || puppeteerModule;
+    browser = await puppeteer.launch({
+      headless: true,
+      args: ["--no-sandbox", "--disable-setuid-sandbox"],
+    });
+
+    const page = await browser.newPage();
+    await page.setContent(html, { waitUntil: "networkidle0" });
+    const pdfBuffer = await page.pdf({
+      format: "A4",
+      printBackground: true,
+      margin: { top: "12mm", right: "10mm", bottom: "12mm", left: "10mm" },
+    });
+
+    res.setHeader("Content-Type", "application/pdf");
+    res.setHeader("Content-Disposition", `attachment; filename=\"${safeFileName}\"`);
+    res.send(pdfBuffer);
+  } catch (error) {
+    console.error("Puppeteer PDF render failed:", error);
+    res.status(500).json({
+      error: "Failed to generate PDF",
+      details: error?.message || "Unknown error",
+      note: "Install puppeteer in this project with `npm install puppeteer` before starting this service.",
+    });
+  } finally {
+    if (browser) await browser.close();
+  }
+});
+
+app.listen(port, () => {
+  console.log(`Puppeteer PDF server running on http://localhost:${port}`);
+});

--- a/src/utils/exportUtils.ts
+++ b/src/utils/exportUtils.ts
@@ -27,6 +27,193 @@ const loadJsPDF = () => new Promise<any>((resolve, reject) => {
   document.head.appendChild(s);
 });
 
+const escapeHtml = (value: string = "") =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+const buildInvoiceHtmlDocument = (bill: Bill, settings: Settings) => {
+  const itemsHtml = bill.items.map((it, idx) => {
+    const lineTotal = it.qty * Math.max(0, it.price - (it.discount || 0));
+    return `
+      <tr>
+        <td>${idx + 1}</td>
+        <td>${escapeHtml(it.name)}</td>
+        <td>${it.qty}</td>
+        <td>₹${it.price}</td>
+        <td>${it.discount ? `₹${it.discount}` : "-"}</td>
+        <td>₹${lineTotal}</td>
+      </tr>
+    `;
+  }).join("");
+
+  return `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <style>
+    @page { size: A4; margin: 12mm; }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: "Inter", "Segoe UI", Arial, sans-serif;
+      color: #1f2937;
+      background: #ffffff;
+    }
+    .invoice {
+      border: 1px solid #e5e7eb;
+      border-radius: 14px;
+      overflow: hidden;
+    }
+    .header {
+      background: linear-gradient(135deg, #0a1f44 0%, #183b7a 100%);
+      color: #fff;
+      padding: 18px 20px;
+      display: flex;
+      justify-content: space-between;
+      gap: 16px;
+    }
+    .title { margin: 0; font-size: 22px; font-weight: 800; letter-spacing: 0.3px; }
+    .sub { margin: 4px 0 0; font-size: 12px; opacity: 0.9; }
+    .content { padding: 20px; }
+    .meta-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+      margin-bottom: 16px;
+    }
+    .card {
+      background: #f8fafc;
+      border: 1px solid #e2e8f0;
+      border-radius: 10px;
+      padding: 12px;
+    }
+    .label {
+      font-size: 10px;
+      text-transform: uppercase;
+      letter-spacing: 0.8px;
+      color: #64748b;
+      margin-bottom: 4px;
+      font-weight: 700;
+    }
+    .value {
+      font-size: 14px;
+      font-weight: 700;
+      color: #0f172a;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 6px;
+      font-size: 12px;
+    }
+    th {
+      text-align: left;
+      background: #eef2ff;
+      border-bottom: 1px solid #dbeafe;
+      color: #1e3a8a;
+      padding: 10px 8px;
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.6px;
+    }
+    td {
+      border-bottom: 1px solid #f1f5f9;
+      padding: 9px 8px;
+      color: #334155;
+    }
+    .totals {
+      margin-top: 16px;
+      margin-left: auto;
+      width: 280px;
+      border: 1px solid #e2e8f0;
+      border-radius: 10px;
+      padding: 12px;
+      background: #f8fafc;
+    }
+    .row { display: flex; justify-content: space-between; margin-bottom: 8px; font-size: 13px; }
+    .row.total {
+      margin-top: 6px;
+      padding-top: 10px;
+      border-top: 1px dashed #cbd5e1;
+      font-size: 18px;
+      font-weight: 800;
+      color: #0a1f44;
+    }
+    .footer {
+      margin-top: 22px;
+      padding-top: 14px;
+      border-top: 1px dashed #cbd5e1;
+      text-align: center;
+      font-size: 11px;
+      color: #64748b;
+    }
+  </style>
+</head>
+<body>
+  <section class="invoice">
+    <div class="header">
+      <div>
+        <h1 class="title">${escapeHtml(settings.shopName || "Invoice")}</h1>
+        <p class="sub">${escapeHtml(settings.address || "-")}</p>
+        <p class="sub">📞 ${escapeHtml(settings.phone || "-")} ${settings.email ? `| ✉️ ${escapeHtml(settings.email)}` : ""}</p>
+      </div>
+      <div style="text-align:right;">
+        <p class="label" style="color:#bfdbfe;margin:0 0 2px;">Invoice No</p>
+        <p class="value" style="color:#fff;margin:0;">#${escapeHtml(bill.id)}</p>
+        <p class="sub">${escapeHtml(bill.date)} ${escapeHtml(bill.time)}</p>
+      </div>
+    </div>
+    <div class="content">
+      <div class="meta-grid">
+        <div class="card">
+          <div class="label">Billed To</div>
+          <div class="value">${escapeHtml(bill.customerObj.name)}</div>
+          <div style="margin-top:4px;font-size:12px;color:#475569;">${escapeHtml(bill.customerObj.phone || "-")}</div>
+        </div>
+        <div class="card">
+          <div class="label">Payment</div>
+          <div class="value">${escapeHtml(bill.paymentMethod)}</div>
+          <div style="margin-top:4px;font-size:12px;color:#475569;">Status: ${escapeHtml(bill.paymentStatus)}</div>
+        </div>
+      </div>
+
+      <table>
+        <thead>
+          <tr>
+            <th style="width: 34px;">#</th>
+            <th>Item</th>
+            <th style="width: 56px;">Qty</th>
+            <th style="width: 74px;">Price</th>
+            <th style="width: 84px;">Discount</th>
+            <th style="width: 84px;">Amount</th>
+          </tr>
+        </thead>
+        <tbody>${itemsHtml}</tbody>
+      </table>
+
+      <div class="totals">
+        <div class="row"><span>Subtotal</span><strong>₹${bill.subtotal}</strong></div>
+        ${bill.discount > 0 ? `<div class="row"><span>Discount</span><strong>-₹${bill.discount}</strong></div>` : ""}
+        <div class="row total"><span>Total</span><span>₹${bill.total}</span></div>
+      </div>
+
+      <div class="footer">
+        <div>Thank you for shopping with us.</div>
+        ${settings.gstId ? `<div style="margin-top:4px;">GSTIN: ${escapeHtml(settings.gstId)}</div>` : ""}
+      </div>
+    </div>
+  </section>
+</body>
+</html>
+  `;
+};
+
 const buildTempInvoice = (bill: Bill, settings: Settings) => {
   const el = document.createElement("div");
   el.style.cssText = "width:400px;background:#fff;padding:24px;font-family:sans-serif;position:fixed;left:-9999px;top:0;z-index:-1;";
@@ -212,6 +399,34 @@ export const doPDF = async (bill: Bill, settings: Settings, setLoading?: (loadin
   if (setLoading) setLoading(true);
   let tempEl: HTMLElement | null = null;
   try {
+    try {
+      const pdfServiceBaseUrl = ((import.meta as any).env?.VITE_PDF_SERVICE_URL || "http://localhost:4173").replace(/\/$/, "");
+      const puppeteerResponse = await fetch(`${pdfServiceBaseUrl}/api/render-invoice-pdf`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          html: buildInvoiceHtmlDocument(bill, settings),
+          fileName: `Invoice_${bill.id}.pdf`,
+        }),
+      });
+
+      if (puppeteerResponse.ok) {
+        const blob = await puppeteerResponse.blob();
+        const fileUrl = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = fileUrl;
+        a.download = `Invoice_${bill.id}.pdf`;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        setTimeout(() => URL.revokeObjectURL(fileUrl), 3000);
+        if (setLoading) setLoading(false);
+        return;
+      }
+    } catch (serviceErr) {
+      console.warn("Puppeteer PDF service unavailable. Falling back to jsPDF.", serviceErr);
+    }
+
     const h2c = await loadHtml2Canvas();
     const JsPDF = await loadJsPDF();
     let el = (invoiceRef && invoiceRef.current) ? invoiceRef.current : null;


### PR DESCRIPTION
### Motivation
- Improve invoice PDF quality and reliability by rendering a styled A4 HTML invoice server-side with Puppeteer while preserving the existing in-browser `html2canvas + jsPDF` path as a fallback.
- Provide a simple local microservice option so large/complex invoices render consistently across environments where client-side capture may fail.

### Description
- Added a small Puppeteer-based PDF microservice at `server/pdfServer.mjs` that exposes `GET /health` and `POST /api/render-invoice-pdf` to convert an HTML document to an A4 PDF response.
- Implemented `buildInvoiceHtmlDocument` and `escapeHtml` in `src/utils/exportUtils.ts` to produce a print-ready, styled invoice HTML payload suitable for Puppeteer rendering.
- Updated `doPDF` in `src/utils/exportUtils.ts` to first attempt PDF generation via the configured service (`VITE_PDF_SERVICE_URL`) and, if unavailable or failing, gracefully fall back to the existing `html2canvas + jsPDF` export.
- Added `npm run pdf:server` script to `package.json`, documented the workflow in `README.md`, and added `VITE_PDF_SERVICE_URL` to `.env.example`.

### Testing
- Ran `npm run lint` (`tsc --noEmit`) and it completed without errors.
- Ran `npm run build` (Vite production build) and it completed successfully.
- Started the local microservice (`node server/pdfServer.mjs`) and verified the health endpoint returned `{ ok: true }`, confirming the server process responds.
- Attempted `npm install puppeteer` in this environment but it failed with a `403 Forbidden` due to registry policy, so dependency installation must be performed in an environment with npm registry access; the code handles a missing service by falling back to the client-side PDF generator.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c62566eff8833296a831021d7e57c5)