### PR TITLE
Add GRAND TOTAL row and highlight CASH/UPI summaries in Excel export

### DIFF
--- a/src/utils/exportUtils.ts
+++ b/src/utils/exportUtils.ts
@@ -509,6 +509,7 @@ export const doExcelExport = (bills: Bill[]) => {
   ]);
 
   // Calculate totals
+  const overallTotal = bills.reduce((acc, b) => acc + b.total, 0);
   const cashTotal = bills.reduce((acc, b) => b.paymentMethod === "CASH" ? acc + b.total : acc, 0);
   const upiTotal = bills.reduce((acc, b) => b.paymentMethod === "UPI" ? acc + b.total : acc, 0);
 
@@ -556,6 +557,18 @@ export const doExcelExport = (bills: Bill[]) => {
     }
   };
 
+  const grandTotalStyle = {
+    font: { bold: true, sz: 13, color: { rgb: "000000" } },
+    fill: { fgColor: { rgb: "FFE699" } },
+    alignment: { horizontal: "right", vertical: "center" },
+    border: {
+      top: { style: "medium", color: { rgb: "000000" } },
+      bottom: { style: "medium", color: { rgb: "000000" } },
+      left: { style: "medium", color: { rgb: "000000" } },
+      right: { style: "medium", color: { rgb: "000000" } }
+    }
+  };
+
   // Apply styles to data range
   const range = XLSX.utils.decode_range(ws['!ref'] || 'A1');
   
@@ -583,10 +596,17 @@ export const doExcelExport = (bills: Bill[]) => {
     }
   }
 
-  // Add 5 empty rows after data
-  const totalStartRow = range.e.r + 5;
+  // Add grand total directly below all bill rows
+  const grandTotalRow = range.e.r + 1;
+  const grandTotalLabelAddr = XLSX.utils.encode_cell({ r: grandTotalRow, c: 5 });
+  const grandTotalValueAddr = XLSX.utils.encode_cell({ r: grandTotalRow, c: 6 });
+  ws[grandTotalLabelAddr] = { v: "GRAND TOTAL (ALL BILLS)", t: "s", s: grandTotalStyle };
+  ws[grandTotalValueAddr] = { v: overallTotal, t: "n", s: grandTotalStyle };
 
-  // Add Cash Total (Skip 5 columns, so start at column index 5 which is 'F')
+  // Keep 4-5 empty lines after grand total and then add highlighted payment summaries
+  const totalStartRow = grandTotalRow + 5;
+
+  // Add Cash Total
   const cashLabelAddr = XLSX.utils.encode_cell({ r: totalStartRow, c: 5 });
   const cashValueAddr = XLSX.utils.encode_cell({ r: totalStartRow, c: 6 });
   ws[cashLabelAddr] = { v: "1) CASH TOTAL", t: 's', s: totalStyle };


### PR DESCRIPTION
### Motivation
- Ensure exported Excel reports clearly show aggregate totals immediately below the data so users can see the overall total without scrolling far down.
- Provide a visually distinct summary for payment-type totals (`CASH` and `UPI`) with spacing and highlighting to make them easy to find.

### Description
- Compute an `overallTotal` with `const overallTotal = bills.reduce((acc, b) => acc + b.total, 0);` and use it for a new grand total row.
- Insert a `GRAND TOTAL (ALL BILLS)` row directly below the bill rows and apply a new `grandTotalStyle` for emphasis (`FFE699` fill, bold font).
- Leave 4–5 empty rows after the grand total, then add highlighted `1) CASH TOTAL` and `2) UPI TOTAL` rows using the existing `totalStyle` to match prominence.
- Update the worksheet range (`ws['!ref']`) to include the added rows and keep existing column auto-width and zebra/data styling logic intact.

### Testing
- Ran the production build with `npm run build` and it completed successfully (Vite build completed; bundle size warning was emitted for large chunks).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c66a91aba88332b5c523f1e7c2dfed)